### PR TITLE
Add debug info and source code, bundling as a tar.gz artifact.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -65,6 +65,13 @@ task:
     - cmake -S /tmp/ponyc/src/libponyrt -B /tmp/ponyc/src/libponyrt/build -DPONY_RUNTIME_BITCODE=true -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${EXTRA_CMAKE_FLAGS}
     - cmake --build /tmp/ponyc/src/libponyrt/build --target libponyrt_bc
 
+  archive_script:
+    - mkdir /tmp/out
+    - cp /tmp/ponyc/src/libponyrt/build/libponyrt.bc /tmp/out/libsavi_runtime.bc
+    - cp -r /tmp/ponyc/src/libponyrt /tmp/out/libsavi_runtime
+    - rm -rf /tmp/out/libsavi_runtime/build
+    - tar -czvf /tmp/libsavi_runtime.tar.gz -C /tmp/out .
+
   publish_if_release_script:
     - echo CIRRUS_RELEASE "${CIRRUS_RELEASE:-NO}"
     - >-
@@ -74,6 +81,6 @@ task:
             -H "Authorization: token ${GITHUB_API_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Content-Type: application/octet-stream" \
-            --data-binary @/tmp/ponyc/src/libponyrt/build/libponyrt.bc \
-            "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=${TRIPLE}-libponyrt.bc" \
+            --data-binary @/tmp/libsavi_runtime.tar.gz \
+            "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=${TRIPLE}-libsavi_runtime.tar.gz" \
       '

--- a/patches/debug_info.patch
+++ b/patches/debug_info.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libponyrt/CMakeLists.txt b/src/libponyrt/CMakeLists.txt
+index 7fd058f..a48c9dd 100644
+--- a/src/libponyrt/CMakeLists.txt
++++ b/src/libponyrt/CMakeLists.txt
+@@ -132,7 +132,7 @@ if(PONY_RUNTIME_BITCODE)
+         #message("${libponyrt_SOURCE_DIR}/${_src_file} -> ${libponyrt_BINARY_DIR}/${_src_file}.bc")
+         get_filename_component(_src_dir ${_src_file} DIRECTORY)
+         add_custom_command(
+-            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_ALWAYS_ASSERT -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -DPONY_VERSION="${PONYC_VERSION}" -DPONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${CMAKE_C_COMPILER_ARCHITECTURE_ID}" -fexceptions -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall -I. -I../common -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
++            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} -O0 -g -fdebug-prefix-map=/tmp/ponyc/src/libponyrt=libsavi_runtime $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_ALWAYS_ASSERT -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -DPONY_VERSION="${PONYC_VERSION}" -DPONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${CMAKE_C_COMPILER_ARCHITECTURE_ID}" -fexceptions -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall -I. -I../common -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
+             WORKING_DIRECTORY ${libponyrt_SOURCE_DIR}
+             DEPENDS "${libponyrt_SOURCE_DIR}/${_src_file}"
+             OUTPUT "${libponyrt_BINARY_DIR}/${_src_file}.bc"


### PR DESCRIPTION
This PR adds debug info to the built runtime bitcode, and bundles the source code referenced by the debug info together with the bitcode itself in a `tar.gz` compressed archive.

This will allow Savi programs to be easily debugged at the runtime level, by allowing the Savi programs to have debug info that refers to source files which are accessible in the Savi distribution package.