### PR TITLE
Publish all release assets into a single bundle for all platforms.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
-task:
-  environment:
+build_task:
+  environment: &environment
     GITHUB_API_TOKEN: ENCRYPTED[636741c0f231293de78980eb83f86c5b8cd5dad07a79351e239c097e42ee4cc0f28113a26f6ad579437e40fcb227066c]
     PONYC_GIT_URL: https://github.com/ponylang/ponyc
     PONYC_VERSION: 0.44.0
@@ -7,6 +7,8 @@ task:
     CXX: clang++
 
   matrix:
+    # (when adding new matrix tasks, also add them as deps to the bundle_task)
+
     - name: x86_64-unknown-linux-gnu
       container:
         image: ubuntu:21.04
@@ -63,7 +65,7 @@ task:
   deps_script:
     - sh -c "${DEPS_INSTALL_PRE:-echo}" && sh -c "${DEPS_INSTALL:-echo}"
 
-  ponyc_clone_script:
+  ponyc_clone_script: &ponyc_clone_script
     - git clone -b ${PONYC_VERSION} --depth 1 ${PONYC_GIT_URL} /tmp/ponyc
     - sh -c "${PATCH_1:-echo}" && sh -c "${PATCH_2:-echo}"
     - cd /tmp/ponyc && git diff
@@ -74,13 +76,72 @@ task:
     - cmake -S /tmp/ponyc/src/libponyrt -B /tmp/ponyc/src/libponyrt/build -DPONY_RUNTIME_BITCODE=true -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${EXTRA_CMAKE_FLAGS}
     - cmake --build /tmp/ponyc/src/libponyrt/build --target libponyrt_bc
 
+  publish_if_release_script:
+    - echo CIRRUS_RELEASE "${CIRRUS_RELEASE:-NO}"
+    - >-
+      sh -c '
+        test -z "${CIRRUS_RELEASE}" || \
+          curl -v --fail -X POST \
+            -H "Authorization: token ${GITHUB_API_TOKEN}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @/tmp/ponyc/src/libponyrt/build/libponyrt.bc \
+            "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=libsavi_runtime-${TRIPLE}.bc" \
+      '
+
+# After each bitcode is published, publish a bundle containing them all.
+bundle_task:
+  depends_on:
+    # Please ensure that this list always has the full set of matrix task names.
+    - x86_64-unknown-linux-musl
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-linux-musl
+    - arm64-unknown-linux-musl
+    - x86_64-unknown-freebsd
+    - x86_64-apple-macosx
+    - arm64-apple-macosx
+  environment: *environment
+  container:
+    image: alpine:3.15
+
+  # Download dependencies. Also explicitly check for the programs we intend
+  # to use only in the release-guarded scripts, since we want to fail fast
+  # on them being missing even on a CI run that isn't a release.
+  deps_script:
+    - apk add --no-cache --update coreutils findutils curl git jq tar gzip
+    - xargs --version
+    - curl --version
+    - jq --version
+
+  # Clone the ponyc source code and patch it for the Savi runtime,
+  # using the exact same script used by the earlier build task matrix.
+  ponyc_clone_script: *ponyc_clone_script
+
+  # Copy the relevant part of the (patched) ponyc source code into /tmp/out.
+  copy_source_script:
+    - mkdir -p /tmp/out
+    - cp -r /tmp/ponyc/src/libponyrt /tmp/out/src
+
+  # Download any/all *.bc files for this release into /tmp/out.
+  download_bitcode_if_release_script:
+    - mkdir -p /tmp/out
+    - >-
+      test -z "${CIRRUS_RELEASE}" || sh -c ' \
+        cd /tmp/out && \
+        curl -v --fail \
+          -H "Authorization: token ${GITHUB_API_TOKEN}" \
+          https://api.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE \
+        | jq -r ".assets[] | select(.name | endswith(\".bc\")) | .browser_download_url" \
+        | xargs -n 1 curl --fail -O \
+          -H "Authorization: token ${GITHUB_API_TOKEN}" \
+      '
+    -
+
+  # Bundle everything in the /tmp/out directory into a single tar archive.
   archive_script:
-    - mkdir /tmp/out
-    - cp /tmp/ponyc/src/libponyrt/build/libponyrt.bc /tmp/out/libsavi_runtime.bc
-    - cp -r /tmp/ponyc/src/libponyrt /tmp/out/libsavi_runtime
-    - rm -rf /tmp/out/libsavi_runtime/build
     - tar -czvf /tmp/libsavi_runtime.tar.gz -C /tmp/out .
 
+  # Publish the bundle as an asset for the release.
   publish_if_release_script:
     - echo CIRRUS_RELEASE "${CIRRUS_RELEASE:-NO}"
     - >-
@@ -91,5 +152,5 @@ task:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @/tmp/libsavi_runtime.tar.gz \
-            "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=${TRIPLE}-libsavi_runtime.tar.gz" \
+            "https://uploads.github.com/repos/$CIRRUS_REPO_FULL_NAME/releases/$CIRRUS_RELEASE/assets?name=libsavi_runtime.tar.gz" \
       '


### PR DESCRIPTION
This will let us in the Savi compiler build automation to easily download the runtime bitcode for every supported platform in one easy step, with each one differentiated by platform name in the downloaded bundle.
